### PR TITLE
Add Docker support for Application and Database

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,60 @@
+## Quick reference
+
+- **Mantained by:**  [Adempiere ERP](http://adempiere.io/)
+- **Where to get help:** [Gitter community ADempiere](https://gitter.im/adempiere/adempiere), [Git Project Adempiere](https://github.com/adempiere/adempiere)
+
+## What is ADempiere?
+
+The ADempiere project was created in September 2006 after a long running disagreement between [ComPiere Inc.](http://wiki.adempiere.io/Difference_With_Compiere), the developers of Compiere™, and the community that formed around that project. The community believed Compiere Inc. placed too much emphasis on the open source lock-in/commercial nature of the project, rather than the community sharing/enriching nature of the project, and after an impassioned discussion decided to split from Compiere™ giving birth to the ADempiere project.
+
+## How to build?
+	
+** Before build: **
+
+	- Build Adempiere Source Code
+	- cd docker
+	- cp ../install/build/Adempiere_393LTS.tar.gz adempiere
+	- cp ../install/build/Adempiere_393LTS.tar.gz adempiere-postgres
+	- tar -xzvf adempiere-postgres/Adempiere_393LTS.tar.gz -C adempiere-postgres/ Adempiere/data/Adempiere_pg.dmp
+	
+	
+
+**Build a Database Image:**
+
+	- docker build -t adempiere.db --build-arg ADEMPIERE_DB=Adempiere_pg.dmp \
+									  --build-arg POSTGRES_RELEASE=14 \
+									   adempiere-postgres
+
+
+**Build a Application Image using Tomcat:** 
+
+	- curl -L https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.63/bin/apache-tomcat-9.0.63.tar.gz > adempiere/apache-tomcat.tar.gz
+	- docker build --build-arg ADEMPIERE_APPS=apache-tomcat.tar.gz \
+					 --build-arg ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz \
+					 --build-arg ADEMPIERE_APPS_TYPE=tomcat \
+					 --build-arg JDK_RELEASE=11-jdk \
+					 -t adempiere.app adempiere
+
+
+**Build a Application Image using Wildfly:**
+
+	- curl -L https://github.com/wildfly/wildfly/releases/download/26.0.1.Final/wildfly-26.0.1.Final.tar.gz > app/wildfly.tar.gz
+	- docker build --build-arg ADEMPIERE_APPS=wildfly.tar.gz \
+					 --build-arg ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz \
+					 --build-arg ADEMPIERE_APPS_TYPE=wildfly \
+					 --build-arg JDK_RELEASE=11-jdk \
+					 -t adempiere.app adempiere
+					 
+**Build a Application Image using Jetty:**
+
+
+	- curl -L https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.8/jetty-home-10.0.8.tar.gz > app/jetty.tar.gz
+	- docker build --build-arg ADEMPIERE_APPS=jetty.tar.gz \
+					 --build-arg ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz \
+					 --build-arg ADEMPIERE_APPS_TYPE=jetty \
+					 --build-arg JDK_RELEASE=11-jdk \
+					 -t adempiere.app adempiere
+					 
+## How to Run?
+
+    docker-compose up -d

--- a/docker/adempiere-postgres/Dockerfile
+++ b/docker/adempiere-postgres/Dockerfile
@@ -1,0 +1,14 @@
+## Postgres Database Service
+ARG POSTGRES_RELEASE $POSTGRES_RELEASE
+FROM postgres:$POSTGRES_RELEASE
+
+ARG ADEMPIERE_DB=Adempiere_pg.dmp
+
+ENV ADEMPIERE_DB $ADEMPIERE_DB
+ENV DB_NAME adempiere
+ENV ADEMPERE_PASSWORD adempiere
+
+ADD --chown=postgres $ADEMPIERE_DB /tmp
+COPY --chown=postgres  initdb.sh /docker-entrypoint-initdb.d
+
+RUN chmod +x /docker-entrypoint-initdb.d/initdb.sh

--- a/docker/adempiere-postgres/initdb.sh
+++ b/docker/adempiere-postgres/initdb.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+if [ "$( psql -U postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_NAME'" )" != '1' ]
+then
+	cd /tmp
+	ls
+    createuser -U postgres adempiere -d -s -l
+    echo "adempiere user created"
+    psql -U postgres -tAc "alter user adempiere password '$ADEMPERE_PASSWORD';"
+    echo "password for adempiere user created"
+    createdb -U adempiere $DB_NAME
+    echo "Database $DB_NAME created"
+    psql -U adempiere -d $DB_NAME < Adempiere_pg.dmp
+    echo "Database $DB_NAME restored"
+    rm Adempiere_pg.dmp
+fi

--- a/docker/adempiere/Dockerfile
+++ b/docker/adempiere/Dockerfile
@@ -1,0 +1,43 @@
+ARG JDK_RELEASE $JDK_RELEASE
+FROM eclipse-temurin:$JDK_RELEASE
+
+#Arguments for Build
+ARG ADEMPIERE_APPS=apache-tomcat.tar.gz
+ARG ADEMPIERE_APPS_TYPE=tomcat
+ARG ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz
+
+#Environments Variables
+ENV ADEMPIERE_DB_TYPE PostgreSQL
+ENV ADEMPIERE_DB_HOST localhost
+ENV ADEMPIERE_DB_PORT 5432
+ENV ADEMPIERE_DB_NAME adempiere
+ENV ADEMPIERE_DB_USER adempiere
+ENV ADEMPIERE_DB_PASSWORD adempiere
+ENV ADEMPIERE_DB_ADMIN_PASSWORD postgres
+ENV ADEMPIERE_WEB_PORT 8888
+ENV ADEMPIERE_SSL_PORT 4443
+ENV ADEMPIERE_JAVA_OPTIONS -Xms128m -Xmx1024m
+ENV ADEMPIERE_HOME /opt/Adempiere
+
+#Set Workdir
+WORKDIR $ADEMPIERE_HOME
+
+#Copy Binary File
+ADD $ADEMPIERE_BINARY /opt/
+ADD $ADEMPIERE_APPS /opt/binaryapp/
+
+#Copy Utilities
+COPY setting.sh /opt/
+COPY entrypoint.sh /opt/
+
+RUN groupadd adempiere && \
+	useradd -r -u 1001 -g adempiere adempiere && \
+	chown -R adempiere $ADEMPIERE_HOME && \
+	chown -R adempiere /opt/binaryapp/ && \
+	/opt/setting.sh
+
+EXPOSE $ADEMPIERE_WEB_PORT
+EXPOSE $ADEMPIERE_SSL_PORT
+
+USER adempiere
+ENTRYPOINT /opt/entrypoint.sh

--- a/docker/adempiere/entrypoint.sh
+++ b/docker/adempiere/entrypoint.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+################################################################################
+#  ADempiere start script                                                     ##
+#  Starting ADempiere Server                                                  ##
+################################################################################
+
+echo "Replace variables on ADempiere Environment File..."
+cd $ADEMPIERE_HOME
+echo "Building..." 
+if [ ! -f Adempiere.properties ] 
+then 
+    sed -i "s|ADEMPIERE_KEYSTORE=C*|ADEMPIERE_KEYSTORE=\/data\/app\/Adempiere\/keystore\/myKeystore|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_TYPE=PostgreSQL|ADEMPIERE_DB_TYPE=$ADEMPIERE_DB_TYPE|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_SERVER=localhost|ADEMPIERE_DB_SERVER=$ADEMPIERE_DB_HOST|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_PORT=5432|ADEMPIERE_DB_PORT=$ADEMPIERE_DB_PORT|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_NAME=adempiere|ADEMPIERE_DB_NAME=$ADEMPIERE_DB_NAME|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_USER=adempiere|ADEMPIERE_DB_USER=$ADEMPIERE_DB_USER|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_PASSWORD=adempiere|ADEMPIERE_DB_PASSWORD=$ADEMPIERE_DB_PASSWORD|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_DB_SYSTEM=postgres|ADEMPIERE_DB_SYSTEM=$ADEMPIERE_DB_ADMIN_PASSWORD|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_APPS_SERVER=0.0.0.0|ADEMPIERE_APPS_SERVER=$(hostname)|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_WEB_PORT=8888|ADEMPIERE_WEB_PORT=$ADEMPIERE_WEB_PORT|g" AdempiereEnv.properties
+    sed -i "s|ADEMPIERE_SSL_PORT=4444|ADEMPIERE_SSL_PORT=$ADEMPIERE_SSL_PORT|g" AdempiereEnv.properties
+    sed -i "s|-Xms128m -Xmx1024m|$ADEMPIERE_JAVA_OPTIONS|g" AdempiereEnv.properties
+    sh RUN_silentsetup.sh 
+fi  
+echo "Running..." 
+utils/RUN_Server2.sh && tail -f /dev/null
+exit 0

--- a/docker/adempiere/setting.sh
+++ b/docker/adempiere/setting.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+################################################################################
+#  ADempiere Setting script                                                   ##
+#  Setting ADempiere Server                                                   ##
+################################################################################
+	
+echo "Setting Binary folder" 
+cd /opt/binaryapp/
+for d in */ ; do [ -L "${d%/}" ] && continue; mv "/opt/binaryapp/$d"* /opt/binaryapp/ ; done
+echo "ADempiere Home..." 
+cd $ADEMPIERE_HOME
+#chmod -Rf 755 *.sh 
+#chmod -Rf 755 utils/*.sh 
+cp AdempiereEnvTemplate.properties AdempiereEnv.properties
+sed -i "s|JAVA_HOME=/usr/lib/jvm/jdk-11|JAVA_HOME=$JAVA_HOME|g" AdempiereEnv.properties 
+sed -i "s|ADEMPIERE_HOME=C.*|ADEMPIERE_HOME=$ADEMPIERE_HOME|g" AdempiereEnv.properties
+sed -i "s|ADEMPIERE_APPS_PATH=/opt/tomcat|ADEMPIERE_APPS_PATH=/opt/binaryapp|g" AdempiereEnv.properties 
+sed -i "s|ADEMPIERE_APPS_TYPE=tomcat|ADEMPIERE_APPS_TYPE=$ADEMPIERE_APPS_TYPE|g" AdempiereEnv.properties

--- a/docker/adempiere/setting.sh
+++ b/docker/adempiere/setting.sh
@@ -9,8 +9,6 @@ cd /opt/binaryapp/
 for d in */ ; do [ -L "${d%/}" ] && continue; mv "/opt/binaryapp/$d"* /opt/binaryapp/ ; done
 echo "ADempiere Home..." 
 cd $ADEMPIERE_HOME
-#chmod -Rf 755 *.sh 
-#chmod -Rf 755 utils/*.sh 
 cp AdempiereEnvTemplate.properties AdempiereEnv.properties
 sed -i "s|JAVA_HOME=/usr/lib/jvm/jdk-11|JAVA_HOME=$JAVA_HOME|g" AdempiereEnv.properties 
 sed -i "s|ADEMPIERE_HOME=C.*|ADEMPIERE_HOME=$ADEMPIERE_HOME|g" AdempiereEnv.properties

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,34 @@
+version: "3.7"
+
+networks:
+  adempiere:
+
+volumes:
+  pgdata:
+
+services:
+  adempiere.db:
+    image: adempiere.db
+    volumes:
+      - "pgdata:/var/lib/postgresql/data"
+    environment:
+      - POSTGRES_PASSWORD=adempiere
+      - DB_NAME=adempiere
+      - ADEMPERE_PASSWORD=adempiere
+    networks:
+      - adempiere
+
+  adempiere.app:
+    image: adempiere.app
+    ports:
+      - "8888:8888"
+    environment:
+      - "ADEMPIERE_DB_HOST=adempiere.db"
+      - "ADEMPIERE_DB_NAME=adempiere"
+      - "ADEMPIERE_DB_PASSWORD=adempiere"
+      - "ADEMPIERE_DB_ADMIN_PASSWORD=adempiere"
+      - "ADEMPIERE_DB_TYPE=oracleXE"
+    depends_on:
+      - adempiere.db
+    networks:
+      - adempiere

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - "ADEMPIERE_DB_NAME=adempiere"
       - "ADEMPIERE_DB_PASSWORD=adempiere"
       - "ADEMPIERE_DB_ADMIN_PASSWORD=adempiere"
-      - "ADEMPIERE_DB_TYPE=oracleXE"
     depends_on:
       - adempiere.db
     networks:


### PR DESCRIPTION
Support to build a docker Adempiere instance

## Step by step to build 

** Before build: **

	- Build Adempiere Source Code
	- cd docker
	- cp ../install/build/Adempiere_393LTS.tar.gz adempiere
	- cp ../install/build/Adempiere_393LTS.tar.gz adempiere-postgres
	- tar -xzvf adempiere-postgres/Adempiere_393LTS.tar.gz -C adempiere-postgres/ Adempiere/data/Adempiere_pg.dmp
	
	

**Build a Database Image:**

	- docker build -t adempiere.db --build-arg ADEMPIERE_DB=Adempiere_pg.dmp \
									  --build-arg POSTGRES_RELEASE=14 \
									   adempiere-postgres


**Build a Application Image using Tomcat:** 

	- curl -L https://dlcdn.apache.org/tomcat/tomcat-9/v9.0.63/bin/apache-tomcat-9.0.63.tar.gz > adempiere/apache-tomcat.tar.gz
	- docker build --build-arg ADEMPIERE_APPS=apache-tomcat.tar.gz \
					 --build-arg ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz \
					 --build-arg ADEMPIERE_APPS_TYPE=tomcat \
					 --build-arg JDK_RELEASE=11-jdk \
					 -t adempiere.app adempiere


**Build a Application Image using Wildfly:**

	- curl -L https://github.com/wildfly/wildfly/releases/download/26.0.1.Final/wildfly-26.0.1.Final.tar.gz > app/wildfly.tar.gz
	- docker build --build-arg ADEMPIERE_APPS=wildfly.tar.gz \
					 --build-arg ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz \
					 --build-arg ADEMPIERE_APPS_TYPE=wildfly \
					 --build-arg JDK_RELEASE=11-jdk \
					 -t adempiere.app adempiere
					 
**Build a Application Image using Jetty:**


	- curl -L https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-home/10.0.8/jetty-home-10.0.8.tar.gz > app/jetty.tar.gz
	- docker build --build-arg ADEMPIERE_APPS=jetty.tar.gz \
					 --build-arg ADEMPIERE_BINARY=Adempiere_393LTS.tar.gz \
					 --build-arg ADEMPIERE_APPS_TYPE=jetty \
					 --build-arg JDK_RELEASE=11-jdk \
					 -t adempiere.app adempiere
					 
## How to Run?

    docker-compose up -d